### PR TITLE
Update Flatpak manifest

### DIFF
--- a/io.itch.domestique_baston.domestique_baston.yml
+++ b/io.itch.domestique_baston.domestique_baston.yml
@@ -25,11 +25,11 @@ modules:
         url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/releases/download/v1.1/db.pck'
         sha256: '45d2a88235e894a54b4f95134166d14c5b4f5b2f3cebf0e4d0a9e67e58b96675'
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.github.domestiquebaston.domestique_baston.desktop'
-        sha256: '8523c9d863da91529c7d1a9e4bc8e04728aa475aa6f41ad9f49a602719aeb628'
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.itch.domestique_baston.domestique_baston.desktop'
+        sha256: '286ae851ee034cb90b52033c2442afddd87f082e1db93689164e49ae0e0b3802'
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.github.domestiquebaston.domestique_baston.metainfo.xml'
-        sha256: '63a54b2063bc2e8d57a39068590baf5e12004ed650c103c5d4270894bf8db12d'
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.itch.domestique_baston.domestique_baston.metainfo.xml'
+        sha256: '6d2af0c40572ba7b46b2b5b5b73f3350f288043f5a63826dac84560b3671acaf'
       - type: file
         url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/icon256.png'
         sha256: '05969263f0a3339ca79bf7d2c12ac43fb04d5d269f6b2e309c51293a7060878c'

--- a/io.itch.domestique_baston.domestique_baston.yml
+++ b/io.itch.domestique_baston.domestique_baston.yml
@@ -1,8 +1,8 @@
 app-id: io.itch.domestique_baston.domestique_baston
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 base: org.godotengine.godot.BaseApp
-base-version: '3.5-23.08'
+base-version: '3.5-24.08'
 sdk: org.freedesktop.Sdk
 command: godot-runner
 finish-args:
@@ -14,13 +14,31 @@ modules:
   - name: domestique_baston
     buildsystem: simple
     build-commands:
-      - install -D -m 0644 DB.pck /app/bin/godot-runner.pck
+      - install -D -m 0644 db.pck /app/bin/godot-runner.pck
       - install -d /app/share/doc/$FLATPAK_ID
       - install -D -m 0644 *.pdf /app/share/doc/$FLATPAK_ID
-      - install -D -m 0644 io.itch.domestique_baston.domestique_baston.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml
-      - install -D -m 0644 io.itch.domestique_baston.domestique_baston.desktop /app/share/applications/$FLATPAK_ID.desktop
+      - install -D -m 0644 $FLATPAK_ID.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml
+      - install -D -m 0644 $FLATPAK_ID.desktop /app/share/applications/$FLATPAK_ID.desktop
       - install -D -m 0644 icon256.png /app/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
     sources:
-      - type: archive
-        url: 'http://www.ferdiferdi.com/db/DB_LIN.zip'
-        sha256: '69d7ef09bdff1e8833a639fc348da309d5fba85179eec3bc2a8601e38bafc71a'
+      - type: file
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/releases/download/v1.1/db.pck'
+        sha256: '45d2a88235e894a54b4f95134166d14c5b4f5b2f3cebf0e4d0a9e67e58b96675'
+      - type: file
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.github.domestiquebaston.domestique_baston.desktop'
+        sha256: '8523c9d863da91529c7d1a9e4bc8e04728aa475aa6f41ad9f49a602719aeb628'
+      - type: file
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.github.domestiquebaston.domestique_baston.metainfo.xml'
+        sha256: '63a54b2063bc2e8d57a39068590baf5e12004ed650c103c5d4270894bf8db12d'
+      - type: file
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/icon256.png'
+        sha256: '05969263f0a3339ca79bf7d2c12ac43fb04d5d269f6b2e309c51293a7060878c'
+      - type: file
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Comment_jouer_How_to_Play.pdf'
+        sha256: '1b4cc73b4457bcdf9a2078d9ff531e80860f249ed61ae63e6a3ab13a3aafcf43'
+      - type: file
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Manuel_Manual.pdf'
+        sha256: 'f6685787910a770a97acae8dab224e8c422ba1671f3dfc19d2dd038dc927b700'
+      - type: file
+        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Aidez_nous_a_ameliorer_le_jeu_help_us_improve_the_game.pdf'
+        sha256: '8fbdd21792386bb9eb72955d8e7a7b65037410471264e46323c4745808bd3ca8'


### PR DESCRIPTION
Bump to freedesktop 24.08.
Fetch files from GitHub, not www.ferdiferdi.com.