### PR TITLE
Update the runtime version from 24.08 to 25.08, and more

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,67 @@
+From 66a200d68123ccd24532ba5c330ef7e9b5152b8a Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sat, 30 May 2026 12:40:43 +0300
+Subject: [PATCH] Fix appdata paper cuts
+
+- Fix missing screenshots
+- Add bugtracker and vcs-browser URLs
+- Fix license information
+
+> P.S. Assets are published under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International licence.
+> Code is published under the GNU General Public License (GPL) v3.0.
+
+Source: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON#domestique-baston
+
+Signed-off-by: Sabri Ünal <yakushabb@gmail.com>
+---
+ io.itch.domestique_baston.domestique_baston.metainfo.xml | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/io.itch.domestique_baston.domestique_baston.metainfo.xml b/io.itch.domestique_baston.domestique_baston.metainfo.xml
+index 70d3f61..9f6c6ea 100644
+--- a/io.itch.domestique_baston.domestique_baston.metainfo.xml
++++ b/io.itch.domestique_baston.domestique_baston.metainfo.xml
+@@ -3,12 +3,14 @@
+ <component type="desktop-application">
+   <id>io.itch.domestique_baston.domestique_baston</id>
+   <name>Domestique Baston</name>
+-  <project_license>GPL-3.0</project_license>
++  <project_license>GPL-3.0 and CC-BY-NC-SA-4.0</project_license>
+   <metadata_license>CC-BY-SA-4.0</metadata_license>
+   <releases>
+     <release version="1.1" date="2023-05-05"/>
+   </releases>
+   <url type="homepage">https://domestique-baston.itch.io/domestique-baston</url>
++  <url type="bugtracker">https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/issues</url>
++  <url type="vcs-browser">https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON</url>
+   <content_rating type="oars-1.0">
+     <content_attribute id="language-humor">mild</content_attribute>
+   </content_rating>
+@@ -52,19 +54,19 @@
+   </description>
+   <screenshots>
+     <screenshot>
+-      <image type="source" width="915" height="515">https://www.ferdiferdi.com/db/01.png</image>
++      <image type="source" width="915" height="515">https://imgproxy.flathub.org/insecure/dpr:2/f:avif/rs:fill-down/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pby9pdGNoL2RvbWVzdGlxdWVfYmFzdG9uLmRvbWVzdGlxdWVfYmFzdG9uL2VlYTZmMmQxOWM4YTUxNzUwYmRhZDIzOGQzNDliODQ3L3NjcmVlbnNob3RzL2ltYWdlLTFfb3JpZy5wbmc</image>
+     </screenshot>
+     <screenshot type="default">
+-      <image type="source" width="915" height="515">https://www.ferdiferdi.com/db/02.png</image>
++      <image type="source" width="915" height="515">https://imgproxy.flathub.org/insecure/dpr:2/f:avif/rs:fill-down/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pby9pdGNoL2RvbWVzdGlxdWVfYmFzdG9uLmRvbWVzdGlxdWVfYmFzdG9uL2VlYTZmMmQxOWM4YTUxNzUwYmRhZDIzOGQzNDliODQ3L3NjcmVlbnNob3RzL2ltYWdlLTJfb3JpZy5wbmc</image>
+     </screenshot>
+     <screenshot>
+-      <image type="source" width="915" height="515">https://www.ferdiferdi.com/db/03.png</image>
++      <image type="source" width="915" height="515">https://imgproxy.flathub.org/insecure/dpr:2/f:avif/rs:fill-down/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pby9pdGNoL2RvbWVzdGlxdWVfYmFzdG9uLmRvbWVzdGlxdWVfYmFzdG9uL2VlYTZmMmQxOWM4YTUxNzUwYmRhZDIzOGQzNDliODQ3L3NjcmVlbnNob3RzL2ltYWdlLTNfb3JpZy5wbmc</image>
+     </screenshot>
+     <screenshot>
+-      <image type="source" width="915" height="515">https://www.ferdiferdi.com/db/04.png</image>
++      <image type="source" width="915" height="515">https://imgproxy.flathub.org/insecure/dpr:2/f:avif/rs:fill-down/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pby9pdGNoL2RvbWVzdGlxdWVfYmFzdG9uLmRvbWVzdGlxdWVfYmFzdG9uL2VlYTZmMmQxOWM4YTUxNzUwYmRhZDIzOGQzNDliODQ3L3NjcmVlbnNob3RzL2ltYWdlLTRfb3JpZy5wbmc</image>
+     </screenshot>
+     <screenshot>
+-      <image type="source" width="915" height="515">https://www.ferdiferdi.com/db/05.png</image>
++      <image type="source" width="915" height="515">https://imgproxy.flathub.org/insecure/dpr:2/f:avif/rs:fill-down/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pby9pdGNoL2RvbWVzdGlxdWVfYmFzdG9uLmRvbWVzdGlxdWVfYmFzdG9uL2VlYTZmMmQxOWM4YTUxNzUwYmRhZDIzOGQzNDliODQ3L3NjcmVlbnNob3RzL2ltYWdlLTVfb3JpZy5wbmc</image>
+     </screenshot>
+   </screenshots>
+ </component>
+--
+libgit2 1.7.2
+

--- a/io.itch.domestique_baston.domestique_baston.yml
+++ b/io.itch.domestique_baston.domestique_baston.yml
@@ -1,8 +1,8 @@
 app-id: io.itch.domestique_baston.domestique_baston
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 base: org.godotengine.godot.BaseApp
-base-version: '3.5-24.08'
+base-version: 3.5-25.08
 sdk: org.freedesktop.Sdk
 command: godot-runner
 finish-args:
@@ -17,28 +17,29 @@ modules:
       - install -D -m 0644 db.pck /app/bin/godot-runner.pck
       - install -d /app/share/doc/$FLATPAK_ID
       - install -D -m 0644 *.pdf /app/share/doc/$FLATPAK_ID
-      - install -D -m 0644 $FLATPAK_ID.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml
-      - install -D -m 0644 $FLATPAK_ID.desktop /app/share/applications/$FLATPAK_ID.desktop
-      - install -D -m 0644 icon256.png /app/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
+      - install -D -m 0644 $FLATPAK_ID.metainfo.xml -t /app/share/metainfo/
+      - install -D -m 0644 $FLATPAK_ID.desktop -t /app/share/applications/
+      - install -D -m 0644 $FLATPAK_ID.png -t /app/share/icons/hicolor/256x256/apps/
     sources:
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/releases/download/v1.1/db.pck'
-        sha256: '45d2a88235e894a54b4f95134166d14c5b4f5b2f3cebf0e4d0a9e67e58b96675'
+        url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/releases/download/v1.1/db.pck
+        sha256: 45d2a88235e894a54b4f95134166d14c5b4f5b2f3cebf0e4d0a9e67e58b96675
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.itch.domestique_baston.domestique_baston.desktop'
-        sha256: '286ae851ee034cb90b52033c2442afddd87f082e1db93689164e49ae0e0b3802'
+        url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.itch.domestique_baston.domestique_baston.desktop
+        sha256: 286ae851ee034cb90b52033c2442afddd87f082e1db93689164e49ae0e0b3802
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.itch.domestique_baston.domestique_baston.metainfo.xml'
-        sha256: '6d2af0c40572ba7b46b2b5b5b73f3350f288043f5a63826dac84560b3671acaf'
+        url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.itch.domestique_baston.domestique_baston.metainfo.xml
+        sha256: 6d2af0c40572ba7b46b2b5b5b73f3350f288043f5a63826dac84560b3671acaf
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/icon256.png'
-        sha256: '05969263f0a3339ca79bf7d2c12ac43fb04d5d269f6b2e309c51293a7060878c'
+        url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/icon256.png
+        sha256: 05969263f0a3339ca79bf7d2c12ac43fb04d5d269f6b2e309c51293a7060878c
+        dest-filename: io.itch.domestique_baston.domestique_baston.png
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Comment_jouer_How_to_Play.pdf'
-        sha256: '1b4cc73b4457bcdf9a2078d9ff531e80860f249ed61ae63e6a3ab13a3aafcf43'
+        url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Comment_jouer_How_to_Play.pdf
+        sha256: 1b4cc73b4457bcdf9a2078d9ff531e80860f249ed61ae63e6a3ab13a3aafcf43
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Manuel_Manual.pdf'
-        sha256: 'f6685787910a770a97acae8dab224e8c422ba1671f3dfc19d2dd038dc927b700'
+        url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Manuel_Manual.pdf
+        sha256: f6685787910a770a97acae8dab224e8c422ba1671f3dfc19d2dd038dc927b700
       - type: file
-        url: 'https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Aidez_nous_a_ameliorer_le_jeu_help_us_improve_the_game.pdf'
-        sha256: '8fbdd21792386bb9eb72955d8e7a7b65037410471264e46323c4745808bd3ca8'
+        url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/Docs/Aidez_nous_a_ameliorer_le_jeu_help_us_improve_the_game.pdf
+        sha256: 8fbdd21792386bb9eb72955d8e7a7b65037410471264e46323c4745808bd3ca8

--- a/io.itch.domestique_baston.domestique_baston.yml
+++ b/io.itch.domestique_baston.domestique_baston.yml
@@ -30,6 +30,8 @@ modules:
       - type: file
         url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/io.itch.domestique_baston.domestique_baston.metainfo.xml
         sha256: 6d2af0c40572ba7b46b2b5b5b73f3350f288043f5a63826dac84560b3671acaf
+      - type: patch
+        path: fix-appdata.patch
       - type: file
         url: https://github.com/DomestiqueBaston/DOMESTIQUE_BASTON/raw/refs/tags/v1.1/icon256.png
         sha256: 05969263f0a3339ca79bf7d2c12ac43fb04d5d269f6b2e309c51293a7060878c


### PR DESCRIPTION
- Update the runtime version to 25.08
- Simplify the install commands
- Comply with Flathub styling guidelines
- Fix appdata paper cuts

See: https://docs.flathub.org/docs/for-app-authors/requirements#flatpak-builder-manifest-style-guide